### PR TITLE
Close receipt tab after printing

### DIFF
--- a/admin/js/receipt-80mm.js
+++ b/admin/js/receipt-80mm.js
@@ -12,6 +12,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
         const sale = JSON.parse(saleDataString);
         populateReceipt(sale);
+        window.addEventListener('afterprint', () => window.close());
         setTimeout(() => window.print(), 500);
     } catch (error) {
         console.error('Failed to render receipt:', error);


### PR DESCRIPTION
## Summary
- Close receipt print tab after printing by listening for `afterprint` and calling `window.close`

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895b4638ad0832a8b7feab33df5167b