### PR TITLE
Close receipt tab after printing

### DIFF
--- a/admin/js/receipt-80mm.js
+++ b/admin/js/receipt-80mm.js
@@ -12,7 +12,21 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
         const sale = JSON.parse(saleDataString);
         populateReceipt(sale);
-        setTimeout(() => window.print(), 500);
+
+        const closeWindow = () => window.close();
+        let printInitiated = false;
+
+        window.addEventListener('afterprint', closeWindow);
+        window.addEventListener('focus', () => {
+            if (printInitiated) {
+                closeWindow();
+            }
+        });
+
+        setTimeout(() => {
+            printInitiated = true;
+            window.print();
+        }, 500);
     } catch (error) {
         console.error('Failed to render receipt:', error);
     }


### PR DESCRIPTION
## Summary
- Close receipt print tab after printing by listening for `afterprint` and window refocus to call `window.close`

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6895b4638ad0832a8b7feab33df5167b