### PR TITLE
feat: add shadcn ui styling to dashboard

### DIFF
--- a/admin/css/dashboard.css
+++ b/admin/css/dashboard.css
@@ -3,43 +3,7 @@
    ========================================================================== */
 
 /* --- 1. Top Statistics Grid (3-Card Row) --- */
-.stats-grid {
-    display: grid;
-    /* On large screens, display all 3 cards in a row */
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-}
-
-/* Styling for each individual stat card */
-.stat-card {
-    background-color: var(--bg-card, #ffffff);
-    padding: 1.5rem;
-    border-radius: var(--radius, 8px);
-    box-shadow: var(--shadow, 0 4px 6px rgba(0,0,0,0.05));
-    border-left: 4px solid var(--primary-color, #3b82f6); /* Accent border on the left */
-}
-.stat-card h3 {
-    font-size: 1rem;
-    color: var(--text-light, #64748b);
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-    font-weight: 600;
-}
-.stat-card .stat-value {
-    font-size: 2.2rem;
-    font-weight: 700;
-    color: var(--primary-dark, #1e293b);
-    line-height: 1.2;
-}
-
-/* Special styling for the warning card (if you add one later) */
-.stat-card.warning {
-    border-left-color: var(--warning, #f59e0b);
-}
-.stat-card.warning .stat-value {
-    color: var(--warning, #d97706);
-}
+/* Stats grid and card styles handled by TailwindCSS */
 
 
 /* ================================================= */
@@ -190,20 +154,15 @@
     }
 
     /* Reduce padding on cards for more content space */
-    .stat-card, .content-card {
+    .content-card {
         padding: 1.25rem;
     }
 
     /* --- 2. Font Size Adjustments --- */
-    
+
     /* Make the main page title smaller */
     .main-content .page-header h1 {
-        font-size: 1.5rem; 
-    }
-
-    /* Reduce the font size of the stat card values */
-    .stat-card .stat-value {
-        font-size: 1.4rem;
+        font-size: 1.5rem;
     }
 
     /* Make the titles inside the content cards smaller */

--- a/admin/dashboard.html
+++ b/admin/dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dashboard - Admin Panel</title>
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="css/admin.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="css/dashboard.css">
@@ -67,35 +68,35 @@
             </header>
 
             <!-- Grid for stats cards -->
-            <div class="stats-grid">
-                <div class="stat-card">
-                    <h3 data-i18n-key="sales_today">Sales Today</h3>
-                    <p id="sales-today" class="stat-value">$0</p>
+            <div class="stats-grid grid gap-6 md:grid-cols-3">
+                <div class="stat-card rounded-lg border bg-white p-6 shadow">
+                    <h3 class="text-sm font-medium text-gray-500" data-i18n-key="sales_today">Sales Today</h3>
+                    <p id="sales-today" class="stat-value text-2xl font-bold">$0</p>
                 </div>
-                <div class="stat-card">
-                    <h3 data-i18n-key="sales_this_month">Sales This Month</h3>
-                    <p id="sales-month" class="stat-value">$0</p>
+                <div class="stat-card rounded-lg border bg-white p-6 shadow">
+                    <h3 class="text-sm font-medium text-gray-500" data-i18n-key="sales_this_month">Sales This Month</h3>
+                    <p id="sales-month" class="stat-value text-2xl font-bold">$0</p>
                 </div>
-                <div class="stat-card">
-                    <h3 data-i18n-key="low_stock_items">Low Stock Items</h3>
-                    <p id="low-stock-count" class="stat-value">0</p>
+                <div class="stat-card rounded-lg border bg-white p-6 shadow">
+                    <h3 class="text-sm font-medium text-gray-500" data-i18n-key="low_stock_items">Low Stock Items</h3>
+                    <p id="low-stock-count" class="stat-value text-2xl font-bold">0</p>
                 </div>
             </div>
 
             <!-- Grid for charts and lists -->
-            <div class="dashboard-grid">
-                <div class="content-card chart-container">
-                    <h3 data-i18n-key="top_selling_products">Top Selling Products (Last 30 Days)</h3>
+            <div class="dashboard-grid grid gap-6 md:grid-cols-2">
+                <div class="content-card chart-container rounded-lg border bg-white p-6 shadow">
+                    <h3 class="text-sm font-medium" data-i18n-key="top_selling_products">Top Selling Products (Last 30 Days)</h3>
                     <canvas id="top-products-chart"></canvas>
                 </div>
-                <div class="content-card">
-                    <h3 data-i18n-key="low_stock_alerts">Low Stock Alerts</h3>
+                <div class="content-card rounded-lg border bg-white p-6 shadow">
+                    <h3 class="text-sm font-medium" data-i18n-key="low_stock_alerts">Low Stock Alerts</h3>
                     <ul id="low-stock-list" class="data-list">
                         <!-- Items will be inserted here by JS -->
                     </ul>
                 </div>
-                <div class="content-card warning">
-                    <h3 data-i18n-key="expiring_soon_title">Expiring Soon (Next 30 Days)</h3>
+                <div class="content-card warning rounded-lg border bg-white p-6 shadow">
+                    <h3 class="text-sm font-medium" data-i18n-key="expiring_soon_title">Expiring Soon (Next 30 Days)</h3>
                     <ul id="expiring-soon-list" class="data-list">
                         <!-- List items will be inserted here by JS -->
                         <li>Loading...</li>


### PR DESCRIPTION
## Summary
- load Tailwind CSS via CDN
- restyle dashboard cards using shadcn/ui-inspired classes
- drop custom stat card CSS in favor of Tailwind

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb39ce520832ab0f7c93a34358df0