### PR TITLE
feat: add revenue chart and interactive dashboard

### DIFF
--- a/admin/css/dashboard.css
+++ b/admin/css/dashboard.css
@@ -3,89 +3,14 @@
    ========================================================================== */
 
 /* --- 1. Top Statistics Grid (3-Card Row) --- */
-.stats-grid {
-    display: grid;
-    /* On large screens, display all 3 cards in a row */
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1.5rem;
-    margin-bottom: 2rem;
-}
-
-/* Styling for each individual stat card */
-.stat-card {
-    background-color: var(--bg-card, #ffffff);
-    padding: 1.5rem;
-    border-radius: var(--radius, 8px);
-    box-shadow: var(--shadow, 0 4px 6px rgba(0,0,0,0.05));
-    border-left: 4px solid var(--primary-color, #3b82f6); /* Accent border on the left */
-}
-.stat-card h3 {
-    font-size: 1rem;
-    color: var(--text-light, #64748b);
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-    font-weight: 600;
-}
-.stat-card .stat-value {
-    font-size: 2.2rem;
-    font-weight: 700;
-    color: var(--primary-dark, #1e293b);
-    line-height: 1.2;
-}
-
-/* Special styling for the warning card (if you add one later) */
-.stat-card.warning {
-    border-left-color: var(--warning, #f59e0b);
-}
-.stat-card.warning .stat-value {
-    color: var(--warning, #d97706);
-}
+/* Stats grid and card styles handled by TailwindCSS */
 
 
 /* ================================================= */
 /* 2. Main Dashboard Grid (Chart & Lists)            */
 /* ================================================= */
 
-.dashboard-grid {
-    display: grid;
-    gap: 1.5rem;
-    
-    /* DESKTOP LAYOUT: 2 Columns (Chart is wider) */
-    /* The first column takes up 1.5 units of space, the second takes up 1 */
-    grid-template-columns: 1fr 1fr; 
-}
-
-/* The first direct child of the grid (the chart container) */
-.dashboard-grid > .content-card:first-child {
-    grid-column: 1;
-    /* Make the chart span two 'rows' to align with the two stacked list cards */
-    grid-row: 1 / 3;
-    margin-bottom: 0px;
-}
-
-/* The second direct child (Low Stock card) */
-.dashboard-grid > .content-card:nth-child(2) {
-    grid-column: 2;
-    grid-row: 1;
-    height: 350px;
-    overflow: scroll;
-    margin-bottom: 0px;
-}
-
-/* The third direct child (Expiring Soon card) */
-.dashboard-grid > .content-card:nth-child(3) {
-    grid-column: 2;
-    grid-row: 2;
-    height: 220px;
-}
-
-
-/* Chart & List Card Styling */
-.chart-container {
-    position: relative;
-    /* A minimum height is good practice */
-    max-height: 600px; 
-}
+/* Dashboard grid layout handled by Tailwind classes */
 
 .data-list {
     list-style: none;
@@ -156,19 +81,6 @@
   .body {
     font-size: 14px;
   }
-    /* Stack the main content cards into a single column */
-    .dashboard-grid {
-        grid-template-columns: 1fr;
-    }
-
-    /* Reset the explicit grid placements from the desktop view */
-    .dashboard-grid > .content-card:first-child,
-    .dashboard-grid > .content-card:nth-child(2),
-    .dashboard-grid > .content-card:nth-child(3) {
-        grid-column: auto;
-        grid-row: auto;
-    }
-
     /* Change the top stats grid to be 2 columns */
     .stats-grid {
         grid-template-columns: repeat(2, 1fr);
@@ -190,20 +102,15 @@
     }
 
     /* Reduce padding on cards for more content space */
-    .stat-card, .content-card {
+    .content-card {
         padding: 1.25rem;
     }
 
     /* --- 2. Font Size Adjustments --- */
-    
+
     /* Make the main page title smaller */
     .main-content .page-header h1 {
-        font-size: 1.5rem; 
-    }
-
-    /* Reduce the font size of the stat card values */
-    .stat-card .stat-value {
-        font-size: 1.4rem;
+        font-size: 1.5rem;
     }
 
     /* Make the titles inside the content cards smaller */
@@ -212,11 +119,6 @@
     }
 
     /* --- 3. Chart & List Adjustments --- */
-
-    /* Reduce the height of the chart on mobile to save vertical space */
-    .chart-container {
-        min-height: 300px;
-    }
 
     /* Reduce the padding and font size for list items */
     .data-list li {
@@ -248,9 +150,4 @@
         color: var(--text-light);
     }
 
-    .dashboard-grid > .content-card:first-child,
-    .dashboard-grid > .content-card:nth-child(2),
-    .dashboard-grid > .content-card:nth-child(3) {
-        width: auto;
-    }
 }

--- a/admin/dashboard.html
+++ b/admin/dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dashboard - Admin Panel</title>
+    <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="css/admin.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="css/dashboard.css">
@@ -67,35 +68,39 @@
             </header>
 
             <!-- Grid for stats cards -->
-            <div class="stats-grid">
-                <div class="stat-card">
-                    <h3 data-i18n-key="sales_today">Sales Today</h3>
-                    <p id="sales-today" class="stat-value">$0</p>
+            <div class="stats-grid grid gap-6 md:grid-cols-3">
+                <div class="stat-card rounded-lg border bg-white p-6 shadow transition-transform hover:shadow-lg hover:scale-[1.02]">
+                    <h3 class="text-sm font-medium text-gray-500" data-i18n-key="sales_today">Sales Today</h3>
+                    <p id="sales-today" class="stat-value text-2xl font-bold">$0</p>
                 </div>
-                <div class="stat-card">
-                    <h3 data-i18n-key="sales_this_month">Sales This Month</h3>
-                    <p id="sales-month" class="stat-value">$0</p>
+                <div class="stat-card rounded-lg border bg-white p-6 shadow transition-transform hover:shadow-lg hover:scale-[1.02]">
+                    <h3 class="text-sm font-medium text-gray-500" data-i18n-key="sales_this_month">Sales This Month</h3>
+                    <p id="sales-month" class="stat-value text-2xl font-bold">$0</p>
                 </div>
-                <div class="stat-card">
-                    <h3 data-i18n-key="low_stock_items">Low Stock Items</h3>
-                    <p id="low-stock-count" class="stat-value">0</p>
+                <div class="stat-card rounded-lg border bg-white p-6 shadow transition-transform hover:shadow-lg hover:scale-[1.02]">
+                    <h3 class="text-sm font-medium text-gray-500" data-i18n-key="low_stock_items">Low Stock Items</h3>
+                    <p id="low-stock-count" class="stat-value text-2xl font-bold">0</p>
                 </div>
             </div>
 
             <!-- Grid for charts and lists -->
-            <div class="dashboard-grid">
-                <div class="content-card chart-container">
-                    <h3 data-i18n-key="top_selling_products">Top Selling Products (Last 30 Days)</h3>
-                    <canvas id="top-products-chart"></canvas>
+            <div class="dashboard-grid grid gap-6 md:grid-cols-2">
+                <div class="revenue-container content-card rounded-lg border bg-white p-6 shadow transition-transform hover:shadow-lg hover:scale-[1.02] md:col-span-2">
+                    <h3 class="text-sm font-medium" data-i18n-key="monthly_revenue">Monthly Revenue</h3>
+                    <canvas id="revenue-chart" class="h-64"></canvas>
                 </div>
-                <div class="content-card">
-                    <h3 data-i18n-key="low_stock_alerts">Low Stock Alerts</h3>
+                <div class="top-products-container content-card rounded-lg border bg-white p-6 shadow transition-transform hover:shadow-lg hover:scale-[1.02] h-[350px] overflow-hidden">
+                    <h3 class="text-sm font-medium" data-i18n-key="top_selling_products">Top Selling Products (Last 30 Days)</h3>
+                    <canvas id="top-products-chart" class="h-[300px]"></canvas>
+                </div>
+                <div class="content-card rounded-lg border bg-white p-6 shadow transition-transform hover:shadow-lg hover:scale-[1.02] h-[350px] overflow-auto">
+                    <h3 class="text-sm font-medium" data-i18n-key="low_stock_alerts">Low Stock Alerts</h3>
                     <ul id="low-stock-list" class="data-list">
                         <!-- Items will be inserted here by JS -->
                     </ul>
                 </div>
-                <div class="content-card warning">
-                    <h3 data-i18n-key="expiring_soon_title">Expiring Soon (Next 30 Days)</h3>
+                <div class="content-card warning rounded-lg border bg-white p-6 shadow transition-transform hover:shadow-lg hover:scale-[1.02] h-[220px] overflow-auto">
+                    <h3 class="text-sm font-medium" data-i18n-key="expiring_soon_title">Expiring Soon (Next 30 Days)</h3>
                     <ul id="expiring-soon-list" class="data-list">
                         <!-- List items will be inserted here by JS -->
                         <li>Loading...</li>

--- a/admin/lang/en.json
+++ b/admin/lang/en.json
@@ -38,6 +38,7 @@
   "sales_today": "Sales Today",
   "sales_this_month": "Sales This Month",
   "low_stock_items": "Low Stock Items",
+  "monthly_revenue": "Monthly Revenue",
   "top_selling_products": "Top Selling Products (Last 30 Days)",
   "low_stock_alerts": "Low Stock Alerts",
   "low_stock_item_details": "(Only {{quantity}} left)",

--- a/admin/lang/km.json
+++ b/admin/lang/km.json
@@ -38,6 +38,7 @@
   "sales_today": "ការលក់ថ្ងៃនេះ",
   "sales_this_month": "ការលក់ខែនេះ",
   "low_stock_items": "ទំនិញជិតអស់ស្តុក",
+  "monthly_revenue": "ចំណូលប្រចាំខែ",
   "top_selling_products": "ទំនិញលក់ដាច់ជាងគេ (30 ថ្ងៃ)",
   "low_stock_alerts": "ឥវ៉ាន់ជិតអស់ស្តុក",
   "low_stock_item_details": "(នៅសល់តែ {{quantity}})",


### PR DESCRIPTION
## Summary
- show monthly revenue chart using Chart.js with month labels
- constrain top selling products panel height and limit to five items
- add translation strings for monthly revenue

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_689cb39ce520832ab0f7c93a34358df0